### PR TITLE
update cli option --epub-metadata (to pandoc 1.19.2.1).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LATEX_CLASS = report
 MATH_FORMULAS = --webtex
 CSS_FILE = style.css
 CSS_ARG = --css=$(CSS_FILE)
-METADATA_ARG = --metadata-file=$(METADATA)
+METADATA_ARG = --epub-metadata=$(METADATA)
 ARGS = $(TOC) $(MATH_FORMULAS) $(CSS_ARG) $(METADATA_ARG)
 
 all: book


### PR DESCRIPTION
fix old command line argument error update.
pandoc 1.19.2.1 in Ubuntu 18.04.

```
$ make
mkdir -p build/epub
pandoc --toc --toc-depth=2 --webtex --css=style.css --metadata-file=metadata.yml --epub-cover-image=images/cover.png -o build/epub/book.epub chapters/*.md
pandoc: unrecognized option `--metadata-file=metadata.yml'
Try pandoc --help for more information.
Makefile:32: recipe for target 'build/epub/book.epub' failed
make: *** [build/epub/book.epub] Error 2
```