### PR TITLE
Replace cp --parent with -P for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(BUILD)/epub/$(OUTPUT_FILENAME).epub:	$(EPUB_DEPENDENCIES)
 $(BUILD)/html/$(OUTPUT_FILENAME).html:	$(HTML_DEPENDENCIES)
 	mkdir -p $(BUILD)/html
 	$(CONTENT) | $(CONTENT_FILTERS) | $(PANDOC_COMMAND) $(ARGS) $(HTML_ARGS) -o $@
-	cp --parent $(IMAGES) $(BUILD)/html/
+	cp -P $(IMAGES) $(BUILD)/html/
 	@echo "$@ was built"
 
 $(BUILD)/pdf/$(OUTPUT_FILENAME).pdf:	$(PDF_DEPENDENCIES)


### PR DESCRIPTION
The `cp` command flag `--parent` is a GNU extension and not [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cp.html). On macOS it fails because the flag is not recognised. On linux the `-P` flag probably means something totally different. See https://man7.org/linux/man-pages/man1/cp.1.html